### PR TITLE
Feature: Add button for ending interviews

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,6 +50,7 @@ func main() {
 	r.GET("/pastInterviews", handlers.ListPastInterviewsHandler)
 	r.GET("/past/:roomID", handlers.GetDocumentSaveHandler)
 	r.GET("/validateKey", handlers.ValidateKeyHandler)
+	r.POST("/endInterview/:roomID", handlers.EndInterviewHandler)
 
 	r.GET("/ws/:roomID", handlers.WebSocketHandler)
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -123,6 +123,24 @@ export async function listPastInterviews(apiKey: string) {
   }
 }
 
+export async function endInterview(roomId: string, apiKey: string) {
+  try {
+    const response = await fetch(`${API_URL}/endInterview/${roomId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      }
+    });
+    return await response.json();
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'Error ending interview'
+    };
+  }
+}
+
 export async function getInterviewContent(interviewId: string, apiKey: string) {
   try {
     const response = await fetch(`${API_URL}/past/${interviewId}`, {

--- a/frontend/src/components/room/EndInterviewModal.tsx
+++ b/frontend/src/components/room/EndInterviewModal.tsx
@@ -1,0 +1,106 @@
+import { useContext, useEffect, useState } from 'react';
+import { DarkModeContext } from '../../App';
+import { endInterview } from '../../api/api';
+
+interface EndInterviewModalProps {
+  roomId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onAttemptStart: () => void;
+  onAttemptError: () => void;
+  onEnded: () => void;
+}
+
+function EndInterviewModal({ roomId, isOpen, onClose, onAttemptStart, onAttemptError, onEnded }: EndInterviewModalProps) {
+  const { isDark } = useContext(DarkModeContext);
+  const storedKey = sessionStorage.getItem('api_key') || '';
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setApiKeyInput('');
+      setError('');
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const needsKeyInput = !storedKey;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const keyToUse = storedKey || apiKeyInput;
+    if (!keyToUse) {
+      setError('API key is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError('');
+    // Mark "we're ending this" before the request so the parent can
+    // suppress the incoming `interview_ended` broadcast (which arrives
+    // ~250ms before the HTTP response returns) from triggering the
+    // "interview has ended" popup intended for other users.
+    onAttemptStart();
+    const response = await endInterview(roomId, keyToUse);
+    setIsSubmitting(false);
+
+    if (response.ok) {
+      // Cache the key for future use (mirrors HomePage / past flows).
+      if (!storedKey) sessionStorage.setItem('api_key', keyToUse);
+      onEnded();
+      return;
+    }
+    onAttemptError();
+    setError(response.error || 'Failed to end interview');
+  };
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm' onClick={onClose}>
+      <form
+        onSubmit={handleSubmit}
+        onClick={(e) => e.stopPropagation()}
+        className={`rounded-xl shadow-2xl p-8 max-w-sm w-full mx-4 ${isDark ? 'bg-slate-800' : 'bg-white'}`}
+      >
+        <h2 className={`text-xl font-bold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>End interview?</h2>
+        <p className={`text-sm mb-6 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+          {needsKeyInput
+            ? 'This will save the code to past interviews and disconnect everyone. Enter your API key to confirm.'
+            : 'This will save the code to past interviews and disconnect everyone.'}
+        </p>
+        {needsKeyInput && (
+          <input
+            type='password'
+            value={apiKeyInput}
+            onChange={(e) => { setApiKeyInput(e.target.value); setError(''); }}
+            placeholder='API key'
+            className={`w-full px-4 py-2 rounded-lg border outline-none mb-2 ${isDark ? 'bg-slate-700 border-slate-600 text-white placeholder-gray-400' : 'bg-gray-50 border-gray-300 text-gray-900'}`}
+            autoFocus
+          />
+        )}
+        <p className='text-red-500 text-sm h-5 mb-2'>{error}</p>
+        <div className='flex gap-3'>
+          <button
+            type='button'
+            onClick={onClose}
+            className={`flex-1 px-6 py-2.5 rounded-lg transition-colors font-semibold ${isDark ? 'bg-slate-700 text-white hover:bg-slate-600' : 'bg-gray-100 text-gray-900 hover:bg-gray-200'}`}
+          >
+            Cancel
+          </button>
+          <button
+            type='submit'
+            disabled={isSubmitting || (needsKeyInput && !apiKeyInput)}
+            className='flex-1 px-6 py-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold disabled:opacity-50'
+          >
+            {isSubmitting ? 'Ending...' : 'End interview'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default EndInterviewModal;

--- a/frontend/src/components/room/RoomPage.tsx
+++ b/frontend/src/components/room/RoomPage.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useContext, useRef } from 'react';
 import { joinRoom, getRoomName } from '../../api/api';
 import EnterName from './EnterName';
 import CodeEditor, { type InterviewType } from './CodeEditor';
+import EndInterviewModal from './EndInterviewModal';
 import Popup from '../popup/Popup';
 import { DarkModeContext, UserContext } from '../../App';
 import { DEFAULT_CODE } from '../../util/reactTemplateContent';
@@ -45,6 +46,10 @@ function RoomPage({ interviewType: propInterviewType }: RoomPageProps) {
   }>>([]);
   const [toasts, setToasts] = useState<Array<{ id: number; message: string }>>([]);
   const toastIdRef = useRef(0);
+  const [showEndConfirmModal, setShowEndConfirmModal] = useState(false);
+  const [endedByMe, setEndedByMe] = useState(false);
+  const [endedByOther, setEndedByOther] = useState(false);
+  const endedByMeRef = useRef(false);
 
   const handleJoinRoom = async () => {
     if (!userName.trim() || !roomId) return;
@@ -222,6 +227,14 @@ function RoomPage({ interviewType: propInterviewType }: RoomPageProps) {
           setCode(message.payload.code);
           break;
 
+        case 'interview_ended':
+          // Suppress the "ended by other" popup for the user who actually
+          // ended it — they get their own success popup from the API call.
+          if (!endedByMeRef.current) {
+            setEndedByOther(true);
+          }
+          break;
+
         case 'visibility_change': {
           const user = users.find(u => u.userId === message.userId);
           const name = message.payload.userName || user?.userName || 'Someone';
@@ -326,6 +339,16 @@ function RoomPage({ interviewType: propInterviewType }: RoomPageProps) {
 
   return (
     <div className={`min-h-screen ${isDark ? 'bg-slate-900 text-white' : 'bg-gray-100 text-gray-900'}`}>
+      <button
+        onClick={() => setShowEndConfirmModal(true)}
+        className={`absolute top-6 right-24 z-50 px-4 py-2 rounded-lg font-semibold transition-colors ${
+          isDark
+            ? 'bg-red-700 text-white hover:bg-red-600'
+            : 'bg-red-600 text-white hover:bg-red-700'
+        }`}
+      >
+        End Interview
+      </button>
       <div className='relative'>
         <h1 className={`absolute top-6 left-0 right-0 text-center text-2xl font-bold z-10 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           {roomName}
@@ -353,6 +376,33 @@ function RoomPage({ interviewType: propInterviewType }: RoomPageProps) {
           </div>
         ))}
       </div>
+
+      <EndInterviewModal
+        roomId={roomId!}
+        isOpen={showEndConfirmModal && !endedByMe && !endedByOther}
+        onClose={() => setShowEndConfirmModal(false)}
+        onAttemptStart={() => { endedByMeRef.current = true; }}
+        onAttemptError={() => { endedByMeRef.current = false; }}
+        onEnded={() => {
+          endedByMeRef.current = true;
+          setEndedByMe(true);
+          setShowEndConfirmModal(false);
+        }}
+      />
+
+      <Popup
+        message='You have successfully ended the interview.'
+        buttonText='Return to home'
+        isOpen={endedByMe}
+        onClickButton={() => navigate('/')}
+      />
+
+      <Popup
+        message='The interview has ended.'
+        buttonText='Return to home'
+        isOpen={!endedByMe && endedByOther}
+        onClickButton={() => navigate('/')}
+      />
     </div>
   );
 }

--- a/handlers/http.go
+++ b/handlers/http.go
@@ -113,6 +113,36 @@ func SwitchLanguageHandler(c *gin.Context) {
 	})
 }
 
+func EndInterviewHandler(c *gin.Context) {
+	apiKey := c.GetHeader("x-api-key")
+	if apiKey == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"ok": false, "error": "API key is required"})
+		return
+	}
+	if apiKey != config.GetAPIKey() {
+		c.JSON(http.StatusForbidden, gin.H{"ok": false, "error": "Invalid API key"})
+		return
+	}
+
+	roomID := c.Param("roomID")
+	if roomID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"ok": false, "error": "Room ID is required"})
+		return
+	}
+
+	if err := services.EndInterview(roomID); err != nil {
+		if errors.Is(err, models.ErrRoomNotFound) {
+			// Already gone — treat as success so a duplicate click still
+			// lets the user navigate home.
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"ok": false, "error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
 func ValidateKeyHandler(c *gin.Context) {
 	apiKey := c.GetHeader("x-api-key")
 	if apiKey == "" {

--- a/handlers/ws.go
+++ b/handlers/ws.go
@@ -119,6 +119,10 @@ func readBroadcastsFromUser(user *models.User, room *models.Room) {
 				continue
 			}
 		}
+		if msg.Type == string(models.InterviewEndedMessageType) {
+			// Clients shouldn't be able to forge end-of-interview events.
+			continue
+		}
 		if msg.Type == string(models.ExecuteRequestMessageType) {
 			if !config.GetEnableCodeExecution() {
 				user.Send <- models.BroadcastMessage{
@@ -157,7 +161,11 @@ func readBroadcastsFromUser(user *models.User, room *models.Room) {
 			}
 			continue
 		}
-		room.Broadcast <- msg
+		select {
+		case room.Broadcast <- msg:
+		case <-room.Done():
+			return
+		}
 	}
 }
 
@@ -167,13 +175,19 @@ func closeUserConnection(user *models.User, room *models.Room) {
 	// First remove user from room so they don't receive their own leave message
 	room.RemoveUser(userID)
 
-	// Broadcast user_left to remaining users
-	room.Broadcast <- models.BroadcastMessage{
-		UserID: userID,
-		Type:   "user_left",
-		Payload: map[string]any{
-			"roomId": room.RoomID,
-		},
+	// Broadcast user_left to remaining users. Skip if the room is ending
+	// or already torn down to avoid blocking forever or panicking on send.
+	if !room.IsEnded() {
+		select {
+		case room.Broadcast <- models.BroadcastMessage{
+			UserID: userID,
+			Type:   "user_left",
+			Payload: map[string]any{
+				"roomId": room.RoomID,
+			},
+		}:
+		case <-room.Done():
+		}
 	}
 
 	// Now clean up the user's resources

--- a/models/room.go
+++ b/models/room.go
@@ -25,6 +25,8 @@ type Room struct {
 	dirty        bool        `json:"-"`
 	lastSave     time.Time   `json:"-"`
 	saveDebounce *time.Timer `json:"-"`
+
+	ended bool `json:"-"`
 }
 
 func NewRoom(roomID, roomName, language, initialCode string) *Room {
@@ -49,8 +51,45 @@ func NewRoom(roomID, roomName, language, initialCode string) *Room {
 }
 
 func (r *Room) Close() {
+	// Only close `done`; leave `Broadcast` open so any in-flight senders
+	// (which select on `done`) can bail out cleanly instead of panicking
+	// on a closed channel. The Broadcast channel will be garbage-collected
+	// once no goroutine references it.
 	close(r.done)
-	close(r.Broadcast)
+}
+
+// Done returns a channel closed when the room is shutting down.
+// Senders to r.Broadcast should select on this to avoid blocking
+// or panicking if the room is being torn down.
+func (r *Room) Done() <-chan struct{} {
+	return r.done
+}
+
+func (r *Room) IsEnded() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ended
+}
+
+// FinalizeAndEnd marks the room ended and flushes the current documents
+// to disk. Returns true if this call performed the transition, false if
+// the room was already ended.
+func (r *Room) FinalizeAndEnd() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ended {
+		return false
+	}
+	r.ended = true
+	if r.saveDebounce != nil {
+		r.saveDebounce.Stop()
+		r.saveDebounce = nil
+	}
+	// Force a save even if no code edits arrived: we want the past
+	// entry to always exist when an interview is explicitly ended.
+	r.dirty = true
+	r.saveToFile()
+	return true
 }
 
 func (r *Room) GetDocument() string {

--- a/models/ws.go
+++ b/models/ws.go
@@ -11,6 +11,7 @@ const (
 	VisibilityChangeMessageType MessageType = "visibility_change"
 	ExecuteRequestMessageType   MessageType = "execute_request"
 	ExecuteResultMessageType    MessageType = "execute_result"
+	InterviewEndedMessageType   MessageType = "interview_ended"
 )
 
 type BroadcastMessage struct {

--- a/services/jobqueue.go
+++ b/services/jobqueue.go
@@ -113,7 +113,8 @@ func handleResultMessage(ctx context.Context, rdb *redis.Client, msg redis.XMess
 
 	// Send execute_result to ALL users in the room (including the one who triggered it).
 	// Using empty UserID so BroadcastToUsers won't skip anyone.
-	room.Broadcast <- models.BroadcastMessage{
+	select {
+	case room.Broadcast <- models.BroadcastMessage{
 		UserID: "",
 		Type:   string(models.ExecuteResultMessageType),
 		Payload: map[string]any{
@@ -122,6 +123,9 @@ func handleResultMessage(ctx context.Context, rdb *redis.Client, msg redis.XMess
 			"stderr": result.Stderr,
 			"code":   result.Code,
 		},
+	}:
+	case <-room.Done():
+		log.Printf("dropping execute_result for ended room %s", result.RoomID)
 	}
 
 	rdb.XAck(ctx, ResultsStream, ServerGroup, msg.ID)

--- a/services/room.go
+++ b/services/room.go
@@ -65,6 +65,51 @@ func GetRoomName(roomID string) (string, error) {
 	return room.RoomName, nil
 }
 
+// EndInterview flushes the room's documents to disk, notifies all connected
+// users via WebSocket, closes their connections, and removes the room from
+// the hub. Idempotent: calling on a missing or already-ended room returns nil.
+func EndInterview(roomID string) error {
+	hub := models.GetHub()
+	room, exists := hub.GetRoom(roomID)
+	if !exists {
+		return models.ErrRoomNotFound
+	}
+
+	if !room.FinalizeAndEnd() {
+		// Already ended by a concurrent call; nothing more to do.
+		return nil
+	}
+
+	// Notify all connected users. Use a system UserID so the existing
+	// "don't send back to sender" check in BroadcastToUsers doesn't filter
+	// it out for anyone.
+	select {
+	case room.Broadcast <- models.BroadcastMessage{
+		UserID:  "system",
+		Type:    string(models.InterviewEndedMessageType),
+		Payload: map[string]any{},
+	}:
+	case <-room.Done():
+	}
+
+	// Give the broadcast a moment to fan out to user websockets before
+	// we tear the room down.
+	time.Sleep(250 * time.Millisecond)
+
+	// Close each user's websocket. Their reader goroutines will exit, run
+	// closeUserConnection, and skip the user_left broadcast because the
+	// room is marked ended.
+	for _, user := range room.GetCurrentUsers() {
+		if user.Conn != nil {
+			user.Conn.Close()
+		}
+	}
+
+	hub.RemoveRoom(roomID)
+	room.Close()
+	return nil
+}
+
 // Goroutine that runs every hour to delete document saves older than 7 days.
 func DeleteRoomSaves() {
 	ticker := time.NewTicker(time.Hour)


### PR DESCRIPTION
## Motivation
When interviews are completed, interviewers need to be able to close the interview room so that the interviewee cannot retroactively edit their code to adjust their performance.

## Implementation
This is implemented using a WebSocket message where, when the interviewer ends the interview, each other user in the room is notified that the interview was ended, each user is prompted to leave the room. Before that happens, all the code content is flushed to disk and the room is deleted from memory after all users leave. For security reasons, ending interviews is gated behind an API key modal, so that only admins with privileged information can end the interview. 

## Testing
This has been tested on a local setup with two users on the same machine, and the implementation worked as intended.